### PR TITLE
Send Authorized API Requests

### DIFF
--- a/grayven/grand_comics_database.py
+++ b/grayven/grand_comics_database.py
@@ -35,11 +35,15 @@ class GrandComicsDatabase:
 
     API_URL = "https://www.comics.org/api"
 
-    def __init__(self, timeout: int = 30, cache: Optional[SQLiteCache] = None):
+    def __init__(
+        self, email: str, password: str, timeout: int = 30, cache: Optional[SQLiteCache] = None
+    ):
         self.headers = {
             "Accept": "application/json",
             "User-Agent": f"Grayven/{__version__}/{platform.system()}: {platform.release()}",
         }
+        self.email = email
+        self.password = password
         self.timeout = timeout
         self.cache = cache
 
@@ -64,7 +68,13 @@ class GrandComicsDatabase:
             params = {}
 
         try:
-            response = get(url, params=params, headers=self.headers, timeout=self.timeout)
+            response = get(
+                url,
+                params=params,
+                headers=self.headers,
+                auth=(self.email, self.password),
+                timeout=self.timeout,
+            )
             response.raise_for_status()
             return response.json()
         except RequestError as err:

--- a/grayven/grand_comics_database.py
+++ b/grayven/grand_comics_database.py
@@ -29,6 +29,8 @@ class GrandComicsDatabase:
     """Class with functionality to request GCD API endpoints.
 
     Args:
+      email: The user's GCD email address, which is used for authentication.
+      password: The user's GCD password, which is used for authentication.'
       timeout: Set how long requests will wait for a response (in seconds).
       cache: SQLiteCache to use if set.
     """

--- a/grayven/grand_comics_database.py
+++ b/grayven/grand_comics_database.py
@@ -30,7 +30,7 @@ class GrandComicsDatabase:
 
     Args:
       email: The user's GCD email address, which is used for authentication.
-      password: The user's GCD password, which is used for authentication.'
+      password: The user's GCD password, which is used for authentication.
       timeout: Set how long requests will wait for a response (in seconds).
       cache: SQLiteCache to use if set.
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 This module contains pytest fixtures.
 """
 
+import os
 from pathlib import Path
 
 import pytest
@@ -12,8 +13,23 @@ from grayven.sqlite_cache import SQLiteCache
 
 
 @pytest.fixture(scope="session")
-def session() -> GrandComicsDatabase:
+def gcd_email() -> str:
+    """Email address for testing."""
+    return os.getenv("GCD_EMAIL")
+
+
+@pytest.fixture(scope="session")
+def gcd_password() -> str:
+    """Password for testing."""
+    return os.getenv("GCD_PASSWORD")
+
+
+@pytest.fixture(scope="session")
+def session(gcd_email: str, gcd_password: str) -> GrandComicsDatabase:
     """Set the GrandComicsDatabase session fixture."""
     return GrandComicsDatabase(
-        cache=SQLiteCache(path=Path("tests/cache.sqlite"), expiry=None), timeout=5
+        email=gcd_email,
+        password=gcd_password,
+        cache=SQLiteCache(path=Path("tests/cache.sqlite"), expiry=None),
+        timeout=5,
     )

--- a/tests/exceptions_test.py
+++ b/tests/exceptions_test.py
@@ -15,8 +15,8 @@ def test_not_found(session: GrandComicsDatabase) -> None:
         session._get_request(endpoint="/invalid")  # noqa: SLF001
 
 
-def test_timeout() -> None:
+def test_timeout(gcd_email: str, gcd_password: str) -> None:
     """Test a TimeoutError for slow responses."""
-    session = GrandComicsDatabase(timeout=1, cache=None)
+    session = GrandComicsDatabase(gcd_email, gcd_password, timeout=1, cache=None)
     with pytest.raises(ServiceError):
         session.get_publisher(id=1)

--- a/tests/issue_test.py
+++ b/tests/issue_test.py
@@ -40,9 +40,13 @@ def issue_no_page_json() -> dict[str, any]:
     }
 
 
-def test_issue_no_page(httpx_mock: HTTPXMock, issue_no_page_json: dict[str, any]) -> None:
+def test_issue_no_page(
+    gcd_email: str, gcd_password: str, httpx_mock: HTTPXMock, issue_no_page_json: dict[str, any]
+) -> None:
     """Test issue with no page count."""
-    session = GrandComicsDatabase()  # We don't want to cache these results
+    session = GrandComicsDatabase(
+        email=gcd_email, password=gcd_password
+    )  # We don't want to cache these results
     httpx_mock.add_response(json=issue_no_page_json)
     result = session.get_issue(2698986)
     assert isinstance(result, Issue)
@@ -63,9 +67,10 @@ def test_issue(session: GrandComicsDatabase) -> None:
     assert result.publication_date == "July 2005"
     assert result.price == "3.50 USD; 4.75 CAD"
     assert result.page_count == Decimal("48")
-    assert (
-        result.editing
-        == "Peter J. Tomasi (credited as  Peter Tomasi) (editor); Harvey Richards (credited) (assistant editor); Dan DiDio (credited) (executive editor); Paul Levitz (credited) (publisher)"  # noqa: E501
+    assert result.editing == (
+        "Peter J. Tomasi (credited as  Peter Tomasi) (editor); Harvey Richards "
+        "(credited) (assistant editor); Dan DiDio (credited) (executive editor); "
+        "Paul Levitz (credited) (publisher)"
     )
     assert result.indicia_publisher == "DC Comics"
     assert result.brand == "DC [bullet]"


### PR DESCRIPTION
This PR add authorization, using the user's GCD email & password.

Anonymous usage is dropped, since 30 per hour isn't terribly useful, and code-wise isn't really workable with the current rate-limiting method.  